### PR TITLE
Fix bug invalid meeting date and time

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -325,6 +325,8 @@ the meeting details will be updated to the new one and a message will inform you
 e.g `mtg john lim m/interview time/23-03-2024 1600-1700` is 
 the same as `mtg John Lim m/interview time/23-03-2024 1600-1700`
 * The specified MEETING_TIME must be of the format dd-MM-YYYY HHmm-HHmm.
+* The MEETING_TIME inputted has to be valid. Note that the timing has to be in the future relative to the
+  current timing.
 * Entering `mtg NAME m/` removes the meeting from the specified contact. <br>
 If the person's contact did not have a meeting and `mtg NAME m/` is entered, 
 an error message will appear and the person's contact will remain the same. 

--- a/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddMeetingCommand.java
@@ -36,7 +36,6 @@ public class AddMeetingCommand extends Command {
 
     public static final String MESSAGE_PERSON_NOT_FOUND = "Oops, %1$s's contact does not exist. Unable to add "
             + "meeting.";
-    public static final String MESSAGE_EMPTY_NAME = "Oops, please state the name of the contact.";
 
     private static Logger logger = Logger.getLogger("MeetingLogger");
     private final String name;
@@ -58,10 +57,6 @@ public class AddMeetingCommand extends Command {
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
         logger.log(Level.INFO, "going to execute the AddMeetingCommand");
-        if (name.isEmpty()) {
-            logger.log(Level.WARNING, "empty name inputted.");
-            throw new CommandException(MESSAGE_EMPTY_NAME);
-        }
         List<Person> contactList = model.getFilteredPersonList();
         Person personToEdit = null;
         for (Person person : contactList) {
@@ -90,7 +85,6 @@ public class AddMeetingCommand extends Command {
                 personToEdit.isStarred(), personToEdit.getRemark(), personToEdit.getTags());
         model.setPerson(personToEdit, editedPerson);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
-
         return new CommandResult(generateSuccessMessage(editedPerson, prevMeeting));
     }
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -5,6 +5,7 @@ import static java.util.Objects.requireNonNull;
 import java.time.LocalDate;
 import java.time.LocalTime;
 import java.time.format.DateTimeFormatter;
+import java.time.format.ResolverStyle;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.Set;
@@ -106,7 +107,7 @@ public class ParserUtil {
     public static LocalTime parseTime(String timeString) {
         requireNonNull(timeString);
         String trimmedTimeString = timeString.trim();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HHmm");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("HHmm").withResolverStyle(ResolverStyle.STRICT);;
         LocalTime time = LocalTime.parse(trimmedTimeString, formatter);
         return time;
     }
@@ -119,7 +120,7 @@ public class ParserUtil {
     public static LocalDate parseDate(String dateString) {
         requireNonNull(dateString);
         String trimmedDateString = dateString.trim();
-        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-yyyy");
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("dd-MM-uuuu").withResolverStyle(ResolverStyle.STRICT);
         LocalDate date = LocalDate.parse(trimmedDateString, formatter);
         return date;
     }

--- a/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddMeetingCommandTest.java
@@ -90,13 +90,6 @@ public class AddMeetingCommandTest {
     }
 
     @Test
-    public void execute_invalidPersonName_throwsCommandException() {
-        AddMeetingCommand addMeetingCommand = new AddMeetingCommand("",
-                new Meeting("Interview", "20-03-2024", "1500", "1600"));
-        assertCommandFailure(addMeetingCommand, model, AddMeetingCommand.MESSAGE_EMPTY_NAME);
-    }
-
-    @Test
     public void execute_emptyMeetingDeleteFailure_throwsCommandException() {
         Person thirdPerson = model.getFilteredPersonList().get(INDEX_THIRD_PERSON.getZeroBased());
         String thirdPersonName = thirdPerson.getName().fullName;

--- a/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddMeetingCommandParserTest.java
@@ -1,7 +1,7 @@
 package seedu.address.logic.parser;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,15 +10,16 @@ import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.Meeting;
 
 public class AddMeetingCommandParserTest {
+    //Some test cases were generated with the help of ChatGPT 3.
 
     private AddMeetingCommandParser parser = new AddMeetingCommandParser();
 
     @Test
     public void parse_validArgs_returnsAddMeetingCommand() throws ParseException {
-        String args = "John m/Meeting time/23-03-2024 1400-1500";
+        String args = "John m/Meeting time/23-03-2025 1400-1500";
         AddMeetingCommand expectedCommand = new AddMeetingCommand("John",
-                new Meeting("Meeting", "23-03-2024", "1400", "1500"));
-        assertEquals(expectedCommand, parser.parse(args));
+                new Meeting("Meeting", "23-03-2025", "1400", "1500"));
+        assertParseSuccess(parser, args, expectedCommand);
     }
 
     @Test
@@ -26,31 +27,49 @@ public class AddMeetingCommandParserTest {
         String args = "John m/";
         AddMeetingCommand expectedCommand = new AddMeetingCommand("John",
                 new Meeting("", "", "", ""));
-        assertEquals(expectedCommand, parser.parse(args));
+        assertParseSuccess(parser, args, expectedCommand);
+    }
+
+    @Test
+    public void parse_missingContactName_throwsParseException() {
+        String args = " m/ time/23-03-2024 1400-1500";
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_EMPTY_NAME);
     }
 
     @Test
     public void parse_missingDescription_throwsParseException() {
         String args = "John m/ time/23-03-2024 1400-1500";
-        assertThrows(ParseException.class, () -> parser.parse(args));
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_EMPTY_DESC);
     }
 
     @Test
     public void parse_missingTiming_throwsParseException() {
         String args = "John m/interview";
-        assertThrows(ParseException.class, () -> parser.parse(args));
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_EMPTY_TIMING);
     }
 
     @Test
     public void parse_invalidDate_throwsParseException() {
-        String args = "John m/Meeting time/2024-03-23 1400-1500";
-        assertThrows(ParseException.class, () -> parser.parse(args));
+        String args = "John m/Meeting time/31-02-2025 1400-1500";
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_INVALID_DATETIME);
     }
 
     @Test
     public void parse_invalidTime_throwsParseException() {
-        String args = "John m/Meeting time/23-03-2024 14:00-15:00";
-        assertThrows(ParseException.class, () -> parser.parse(args));
+        String args = "John m/Meeting time/23-03-2025 1400-2400";
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_INVALID_DATETIME);
+    }
+
+    @Test
+    public void parse_invalidTimeInPast_throwsParseException() {
+        String args = "John m/Meeting time/23-03-1999 1400-1500";
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_TIME_IN_PAST);
+    }
+
+    @Test
+    public void parse_illogicalTime_throwsParseException() {
+        String args = "John m/Meeting time/23-03-2025 1900-1200";
+        assertParseFailure(parser, args, AddMeetingCommandParser.MESSAGE_TIMING_BACKWARDS);
     }
 
 }


### PR DESCRIPTION
Fixed bugs #170, #138, #137, #130. 
Updated AddMeetingCommandParser to raise error messages for invalid date and time (e.g 31 Feb will throw an error). Will throw error when user tries to add a meeting with a timing in the past. 

Also fixed bugs #166, #135, #133.
Updated AddMeetingCommandParser similarly to raise an error if user tries to assign backwards timing for the meeting. (illogical) e.g 1700-1200 will throw an error

Fixed minor documentation bug #128 in error message.